### PR TITLE
data: add fetch-epa-ecoregions.js pipeline script (Issue 2)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,29 +68,35 @@
 
 **Branch:** `data/epa-ecoregions`  
 **Label:** `data`  
-**Scope:** `data/regions.geojson` (regenerate), `scripts/extract-regions.js` (adjust if needed)
+**Scope:** `data/regions.geojson` (regenerate), `scripts/extract-regions.js`, `scripts/fetch-epa-ecoregions.js`
 
-**What:** Replace the interim hand-drawn polygons in `data/regions.geojson` with authoritative EPA Level III ecoregion boundaries. The pipeline script `scripts/extract-regions.js` is already written.
+**Status:** Scripts complete — `data/regions.geojson` remains on improved interim polygons pending network access to `geodata.epa.gov`.
 
-**Steps:**
-1. Fetch paginated EPA ArcGIS REST endpoint:
-   ```
-   https://geodata.epa.gov/arcgis/rest/services/OA/EcoregionsByState/MapServer/1/query
-   ?where=1%3D1&outFields=US_L3CODE,US_L3NAME&f=geojson&resultOffset=0&resultRecordCount=1000
-   ```
-2. Merge pages into `/tmp/us_eco_l3.geojson`
-3. Run: `node scripts/extract-regions.js /tmp/us_eco_l3.geojson data/regions.geojson`
-4. Verify output has all 5 region keys, file < 2 MB
-5. All 280 unit tests pass; all 85 E2E tests pass
+**What:** Replace the interim hand-drawn polygons in `data/regions.geojson` with authoritative EPA Level III ecoregion boundaries.
 
-**L3 → region mapping** (already in `scripts/extract-regions.js`):
+**Full pipeline (run from a machine with access to geodata.epa.gov):**
+```bash
+# Step 1 — fetch all EPA L3 features (paginates automatically)
+node scripts/fetch-epa-ecoregions.js /tmp/us_eco_l3.geojson
+
+# Step 2 — extract + map to Ridge to Coast region keys
+node scripts/extract-regions.js /tmp/us_eco_l3.geojson data/regions.geojson
+
+# Step 3 — verify
+node --test tests/geo.test.js   # must pass 280/280
+```
+
+**L3 → region mapping** (in `scripts/extract-regions.js`):
 - `63, 65, 83` → `coastal`
 - `45, 64, 58, 59, 84` → `piedmont`
 - `66` → `blueRidge`
 - `67–71, 78–81` → `valleyRidge`
 - `73–76` → `gulfCoastal`
 
-**Note:** If ArcGIS endpoint is blocked, use `node scripts/generate-regions.js` (interim, uses existing inline polygons).
+**Fallback (no network):**
+```bash
+node scripts/generate-regions.js   # regenerates from inline polygons in lib/geo-data.js
+```
 
 ---
 

--- a/scripts/fetch-epa-ecoregions.js
+++ b/scripts/fetch-epa-ecoregions.js
@@ -1,0 +1,131 @@
+/**
+ * scripts/fetch-epa-ecoregions.js
+ * ────────────────────────────────
+ * Downloads all EPA Level III Ecoregion features from the public ArcGIS
+ * REST API and writes them to /tmp/us_eco_l3.geojson, ready for
+ * scripts/extract-regions.js to process into data/regions.geojson.
+ *
+ * ── Usage ─────────────────────────────────────────────────────────────────
+ *   node scripts/fetch-epa-ecoregions.js [output]
+ *
+ *   Default output: /tmp/us_eco_l3.geojson
+ *
+ * ── Full pipeline ─────────────────────────────────────────────────────────
+ *   node scripts/fetch-epa-ecoregions.js
+ *   node scripts/extract-regions.js /tmp/us_eco_l3.geojson data/regions.geojson
+ *
+ * ── Data source ───────────────────────────────────────────────────────────
+ *   US EPA Level III Ecoregions of the Conterminous United States
+ *   ArcGIS REST MapServer — public, no API key required.
+ *   https://geodata.epa.gov/arcgis/rest/services/OA/EcoregionsByState/MapServer/1
+ *
+ * ── Network requirement ───────────────────────────────────────────────────
+ *   Requires outbound HTTPS to geodata.epa.gov.
+ *   If blocked, generate interim polygons instead:
+ *     node scripts/generate-regions.js
+ *
+ * ── How it works ──────────────────────────────────────────────────────────
+ *   The ArcGIS REST API paginates results (default max 1000 per page).
+ *   This script walks all pages using resultOffset until the server
+ *   signals the last page (exceededTransferLimit: false or fewer features
+ *   than the page size).  All features are merged into a single
+ *   FeatureCollection and written to disk.
+ */
+
+'use strict';
+
+const fs      = require('fs');
+const https   = require('https');
+const path    = require('path');
+const { URL } = require('url');
+
+const OUTPUT  = process.argv[2] || '/tmp/us_eco_l3.geojson';
+const BASE    = 'https://geodata.epa.gov/arcgis/rest/services/OA/EcoregionsByState/MapServer/1/query';
+const PAGE    = 1000;   // features per request (server max is typically 1000)
+
+/** Fetch one page of GeoJSON and return the parsed object. */
+function fetchPage(offset) {
+  const url = new URL(BASE);
+  url.searchParams.set('where',            '1=1');
+  url.searchParams.set('outFields',        'US_L3CODE,US_L3NAME');
+  url.searchParams.set('f',                'geojson');
+  url.searchParams.set('resultOffset',     String(offset));
+  url.searchParams.set('resultRecordCount', String(PAGE));
+
+  return new Promise((resolve, reject) => {
+    const req = https.get(url.toString(), (res) => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`HTTP ${res.statusCode} for offset ${offset}`));
+        res.resume();
+        return;
+      }
+      const chunks = [];
+      res.on('data', chunk => chunks.push(chunk));
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+        } catch (e) {
+          reject(new Error(`JSON parse error at offset ${offset}: ${e.message}`));
+        }
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(30_000, () => {
+      req.destroy(new Error(`Timeout fetching offset ${offset}`));
+    });
+  });
+}
+
+async function main() {
+  const allFeatures = [];
+  let offset = 0;
+  let page   = 1;
+
+  process.stderr.write('Fetching EPA Level III Ecoregions from ArcGIS REST API...\n');
+
+  for (;;) {
+    process.stderr.write(`  Page ${page} (offset ${offset})...`);
+    let data;
+    try {
+      data = await fetchPage(offset);
+    } catch (err) {
+      process.stderr.write('\n');
+      console.error(`\nFetch error: ${err.message}`);
+      console.error('\nIf geodata.epa.gov is unreachable, use the interim generator:');
+      console.error('  node scripts/generate-regions.js');
+      process.exit(1);
+    }
+
+    const features = data.features || [];
+    process.stderr.write(` ${features.length} features\n`);
+    allFeatures.push(...features);
+
+    // ArcGIS signals "more pages" via exceededTransferLimit: true
+    if (!data.exceededTransferLimit || features.length < PAGE) break;
+
+    offset += PAGE;
+    page++;
+  }
+
+  process.stderr.write(`\nTotal features fetched: ${allFeatures.length}\n`);
+
+  const geojson = {
+    type:     'FeatureCollection',
+    _meta: {
+      source:    'EPA ArcGIS REST — EcoregionsByState/MapServer/1',
+      fetched:   new Date().toISOString().slice(0, 10),
+      features:  allFeatures.length,
+    },
+    features: allFeatures,
+  };
+
+  fs.mkdirSync(path.dirname(path.resolve(OUTPUT)), { recursive: true });
+  fs.writeFileSync(OUTPUT, JSON.stringify(geojson));
+
+  const kb = (fs.statSync(OUTPUT).size / 1024).toFixed(1);
+  process.stderr.write(`Written: ${OUTPUT} (${kb} KB)\n`);
+  process.stderr.write('\nNext step:\n');
+  process.stderr.write(`  node scripts/extract-regions.js ${OUTPUT} data/regions.geojson\n`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Roadmap Issue 2 — EPA Level III region data.

- Adds `scripts/fetch-epa-ecoregions.js` — the missing companion to `scripts/extract-regions.js`. Paginates the EPA ArcGIS REST API and writes a merged FeatureCollection to `/tmp/us_eco_l3.geojson`.
- Updates `ROADMAP.md` Issue 2 with the full two-step pipeline and fallback instructions.

## Pipeline (run from a machine with access to geodata.epa.gov)

```bash
node scripts/fetch-epa-ecoregions.js
node scripts/extract-regions.js /tmp/us_eco_l3.geojson data/regions.geojson
node --test tests/geo.test.js
```

## Why data/regions.geojson is unchanged

`geodata.epa.gov` is not reachable from the current build environment (host not in network allowlist). `data/regions.geojson` continues to use the improved interim hand-drawn polygons from the boundary-fix commit. The fetch script is ready to run the moment network access is available.

## Test plan

- [x] 280/280 unit tests pass
- [ ] When network access is available: run full pipeline, verify 5 region keys, file < 2 MB, all tests pass

https://claude.ai/code/session_01PPP7HM6VpT3KSoRaXQ23Lp