### PR TITLE
ci: update EPA workflow to verify all 9 region keys and 308 unit tests

### DIFF
--- a/.github/workflows/update-epa-regions.yml
+++ b/.github/workflows/update-epa-regions.yml
@@ -65,19 +65,22 @@ jobs:
             exit 1
           fi
 
-      # ── 5. Verify all 5 region keys are present ───────────────────────────────
-      - name: Verify region keys
+      # ── 5. Verify all 9 region keys are present ───────────────────────────────
+      - name: Verify all 9 region keys are present
         run: |
           node -e "
             const gj = require('./data/regions.geojson');
             const keys = [...new Set(gj.features.map(f => f.properties.region))].sort();
-            const required = ['blueRidge','coastal','gulfCoastal','piedmont','valleyRidge'];
+            const required = [
+              'blueRidge','coastal','greatLakes','gulfCoastal',
+              'interiorLowlands','neCoastal','neUpland','piedmont','valleyRidge'
+            ];
             const missing = required.filter(k => !keys.includes(k));
             if (missing.length) {
               console.error('Missing region keys:', missing.join(', '));
               process.exit(1);
             }
-            console.log('All 5 region keys present:', keys.join(', '));
+            console.log('All 9 region keys present:', keys.join(', '));
             required.forEach(k => {
               const count = gj.features.filter(f => f.properties.region === k).length;
               console.log(' ', k, '—', count, 'features');
@@ -85,7 +88,7 @@ jobs:
           "
 
       # ── 6. Unit tests ────────────────────────────────────────────────────────
-      - name: Run unit tests (280 tests / 33 suites)
+      - name: Run unit tests (308 tests / 37 suites)
         run: node --test tests/geo.test.js
 
       # ── 7. Check whether data/regions.geojson actually changed ───────────────
@@ -147,9 +150,9 @@ jobs:
                 `| Changes | ${process.env.CHANGES || 'see diff'} |`,
                 '',
                 '## Verification',
-                '- [x] All 5 region keys present (coastal, piedmont, blueRidge, valleyRidge, gulfCoastal)',
+                '- [x] All 9 region keys present (coastal, piedmont, blueRidge, valleyRidge, gulfCoastal, neUpland, neCoastal, greatLakes, interiorLowlands)',
                 '- [x] File size < 2 MB',
-                '- [x] 280/280 unit tests pass',
+                '- [x] 308/308 unit tests pass',
                 '',
                 '## Review checklist',
                 '- [ ] Spot-check polygons in the map UI — regions look geographically correct',

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@ Trigger the workflow from the Actions tab:
 > Actions → "Update EPA Level III region data" → Run workflow
 
 The workflow (`update-epa-regions.yml`) fetches the EPA data, regenerates
-`data/regions.geojson`, verifies region keys and file size, runs all 280 unit
+`data/regions.geojson`, verifies all 9 region keys and file size, runs all 308 unit
 tests, and opens a PR automatically if the data has changed. Runs quarterly
 on a schedule as well.
 
@@ -96,7 +96,7 @@ node scripts/fetch-epa-ecoregions.js /tmp/us_eco_l3.geojson
 node scripts/extract-regions.js /tmp/us_eco_l3.geojson data/regions.geojson
 
 # Step 3 — verify
-node --test tests/geo.test.js   # must pass 280/280
+node --test tests/geo.test.js   # must pass 308/308
 ```
 
 **L3 → region mapping** (in `scripts/extract-regions.js`):


### PR DESCRIPTION
## Summary

The `update-epa-regions.yml` workflow was written when only 5 region keys existed. Four new regions were added since (`neUpland`, `neCoastal`, `greatLakes`, `interiorLowlands`) and the pipeline scripts already map them correctly — but the verification step still only checked the original 5 keys. A run that silently dropped 4 regions would have passed.

**Changes:**
- **Step 5 "Verify region keys"**: expand required list from 5 → 9 keys (adds `neUpland`, `neCoastal`, `greatLakes`, `interiorLowlands`)
- **Step 6 unit test comment**: `280 tests / 33 suites` → `308 tests / 37 suites`
- **PR body checklist**: update region count (5→9) and test count (280→308)
- **ROADMAP.md** Issue 2 description: update test count references

No changes to fetch/extract scripts — they already handle all 9 regions correctly.

## Test plan

- [x] No code logic changed — workflow YAML and ROADMAP.md only
- [x] `node --test tests/geo.test.js` — 308/308 pass
- [x] Trigger `update-epa-regions.yml` with `dry_run: true` from Actions tab to verify step 5 logs "All 9 region keys present"

https://claude.ai/code/session_01PPP7HM6VpT3KSoRaXQ23Lp