### PR TITLE
feat: tighter default view + smaller city markers

### DIFF
--- a/map.js
+++ b/map.js
@@ -93,8 +93,8 @@ document.getElementById('back-btn').addEventListener('click', function () {
 /* ─── Map initialization ────────────────────────────────────── */
 
 var map = L.map('map', {
-  center: [37.5, -78.0],
-  zoom: 7,
+  center: [38.9, -77.0],
+  zoom: 8,
   zoomControl: true,
   attributionControl: false,
 });
@@ -235,10 +235,10 @@ loadRegions();
    ────────────────────────────────────────────────────────────── */
 
 var CITY_MARKER_STYLE = {
-  radius:      7,
+  radius:      4,
   fillColor:   '#ffffff',
   color:       '#e84393',
-  weight:      2.5,
+  weight:      2,
   opacity:     1,
   fillOpacity: 0.9,
 };
@@ -257,7 +257,7 @@ gd.CORRIDOR_CITIES.forEach(function (city) {
     className:  'city-tooltip',
   });
   marker.on('mouseover', function () {
-    this.setStyle({ radius: 9, fillColor: '#e84393', fillOpacity: 1 });
+    this.setStyle({ radius: 6, fillColor: '#e84393', fillOpacity: 1 });
     this.getElement() && (this.getElement().style.cursor = 'pointer');
   });
   marker.on('mouseout', function () {

--- a/style.css
+++ b/style.css
@@ -139,10 +139,10 @@ html, body {
 
 .swatch.citymarker {
   background: #fff;
-  border: 2.5px solid #e84393;
+  border: 2px solid #e84393;
   border-radius: 50%;
-  width: 14px;
-  height: 14px;
+  width: 9px;
+  height: 9px;
 }
 
 #legend hr {


### PR DESCRIPTION
## Summary

- **Default view**: center `[37.5, -78.0]` zoom 7 → Washington DC `[38.9, -77.0]` zoom 8. Opens on the fall line / piedmont–coastal boundary, spanning hardiness zones 6b–8a and multiple regions (coastal, piedmont, blue ridge visible to the west) — close enough to read individual city markers
- **Marker size**: radius 7 → 4 (halved); hover radius 9 → 6; stroke weight 2.5 → 2
- **Legend swatch**: citymarker swatch scaled down to match (14 px → 9 px)

## Test plan

- [x] Load the map — opens centred on Washington DC at zoom 8
- [x] City markers are visibly smaller and less cluttered at the default zoom
- [x] Hovering a marker still produces a clear highlight (radius 6, pink fill)
- [x] Legend citymarker swatch matches the on-map marker size

https://claude.ai/code/session_01PPP7HM6VpT3KSoRaXQ23Lp