### PR TITLE
Docs/roadmap issues

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,239 +1,67 @@
-# Ridge to Coast — Roadmap & Backlog
+# Ridge to Coast — Roadmap
 
-## Current State (master as of April 2026)
+## Phase 1 — Complete ✅
 
-| Item | Status |
-|---|---|
-| Rename to Ridge to Coast | ✅ |
-| Blue Ridge region (polygon, plants, soil, 6 cities) | ✅ |
-| Valley & Ridge region (WV, KY, eastern OH) | ✅ |
-| NE Upland / NE Coastal regions (VT, NH, ME, Lake Erie) | ✅ |
-| Gulf Coastal Plain (FL, GA coast, AL, MS, Memphis embayment) | ✅ |
-| Rivers — invisible interactive layer (tooltip + detail page) | ✅ |
-| Hardiness zones — 22 states (was 8) | ✅ |
-| Hash routing detail pages (`#detail/region/`, `#detail/zone/`, `#detail/river/`) | ✅ |
-| `data/regions.geojson` async fetch architecture (EPA-ready) | ✅ |
-| 280 unit tests / 33 suites, 85 E2E tests | ✅ |
-| README update | ❌ |
-| EPA Level III authoritative region polygons | ❌ |
-| Native plant expansion (10+ per region, currently 6) | ❌ |
-| Invasive species warnings per region | ❌ |
-| Seasonal planting calendar per zone | ❌ |
-| City marker expansion (30+ cities, currently 21) | ❌ |
+All merged to `master`. 280 unit tests · 85 E2E tests.
+
+- 6 region polygons: Coastal Plain, Piedmont, Blue Ridge, Valley & Ridge, NE Upland, NE Coastal, Gulf Coastal Plain
+- 21+ city markers · native plants + soil + invasive species per region · planting calendar per zone
+- Rivers interactive layer · hardiness zones 22 states · hash routing detail pages
+- `data/regions.geojson` async fetch architecture (EPA-ready)
 
 ---
 
-## Issue 1 — README update
+## Phase 2 — Living Data
 
-**Branch:** `docs/readme-update`  
-**Label:** `docs`  
-**Scope:** `README.md` only — no code changes, no test changes
+Free public APIs + OpenStreetMap. No backend required.
 
-**Changes needed:**
-- Intro: replace "fall line corridor, 8 states" → full eastern corridor, 22 states, 6 regions, 21 cities
-- "What it shows" table: add Blue Ridge, Valley & Ridge, NE Upland, NE Coastal, Gulf Coastal, rivers (interactive), detail pages
-- Update city marker count: 15 → 21
-- Update hardiness: 8 states / zones 5a–9a → 22 states / zones 3b–10a
-- Unit tests: 172 / 20 suites → 280 / 33 suites
-- E2E tests: 71 → 85; per-file: test_map.py 19→31, test_markers.py 12→14
-- Project structure: add `data/regions.geojson`, `scripts/extract-regions.js`, `scripts/generate-regions.js`
-- Hardiness pipeline code block: update state list from 8 to 22 states
-- Suite table: add suites 21–33
-
-**Suite names 21–33** (from `node --test tests/geo.test.js`):
-21. BLUE_RIDGE_GEOJSON structure
-22. Blue Ridge ecological data
-23. Appalachian city markers
-24. Detail page HTML generators
-25. classifyLocation and makeLocationReport
-26. NE_FALL_ZONE_GEOJSON structure
-27. MAJOR_RIVERS_GEOJSON structure
-28. makeRiverDetailHTML()
-29. VALLEY_RIDGE_GEOJSON structure
-30. Valley and Ridge ecological data
-31. NE_UPLAND_GEOJSON structure
-32. NE_COASTAL_GEOJSON structure
-33. Blue Ridge escarpment shared boundaries
-
-**E2E counts per file:**
-- `test_map.py` — 31
-- `test_search.py` — 12
-- `test_legend_toggle.py` — 9
-- `test_markers.py` — 14
-- `test_visual_rendering.py` — 19
+| # | Title | Labels |
+|---|---|---|
+| [#11](https://github.com/loobo07/loobo07.github.io/issues/11) | NWS frost advisory — "Plant now?" in zone detail pages | `phase-2` `api-integration` |
+| [#12](https://github.com/loobo07/loobo07.github.io/issues/12) | Location report page (`#detail/location/lat/lon`) | `phase-2` |
+| [#13](https://github.com/loobo07/loobo07.github.io/issues/13) | USGS streamflow status on river detail pages | `phase-2` `api-integration` |
+| [#14](https://github.com/loobo07/loobo07.github.io/issues/14) | Community gardens + native plant nurseries layer (OpenStreetMap) | `phase-2` `data` |
+| [#15](https://github.com/loobo07/loobo07.github.io/issues/15) | iNaturalist recent observations badge per region | `phase-2` `api-integration` |
+| [#16](https://github.com/loobo07/loobo07.github.io/issues/16) | Watershed delineation — click map to see contributing watershed | `phase-2` `api-integration` |
+| [#17](https://github.com/loobo07/loobo07.github.io/issues/17) | PWA service worker — offline map access | `phase-2` `pwa` |
 
 ---
 
-## Issue 2 — EPA Level III region data
+## Phase 3 — REST API
 
-**Branch:** `data/epa-ecoregions`  
-**Label:** `data`  
-**Scope:** `data/regions.geojson` (regenerate), `scripts/extract-regions.js` (adjust if needed)
+Serverless (Cloudflare Workers). Spec-first: write #18 before implementing #19–#22.
 
-**What:** Replace the interim hand-drawn polygons in `data/regions.geojson` with authoritative EPA Level III ecoregion boundaries. The pipeline script `scripts/extract-regions.js` is already written.
-
-**Steps:**
-1. Fetch paginated EPA ArcGIS REST endpoint:
-   ```
-   https://geodata.epa.gov/arcgis/rest/services/OA/EcoregionsByState/MapServer/1/query
-   ?where=1%3D1&outFields=US_L3CODE,US_L3NAME&f=geojson&resultOffset=0&resultRecordCount=1000
-   ```
-2. Merge pages into `/tmp/us_eco_l3.geojson`
-3. Run: `node scripts/extract-regions.js /tmp/us_eco_l3.geojson data/regions.geojson`
-4. Verify output has all 5 region keys, file < 2 MB
-5. All 280 unit tests pass; all 85 E2E tests pass
-
-**L3 → region mapping** (already in `scripts/extract-regions.js`):
-- `63, 65, 83` → `coastal`
-- `45, 64, 58, 59, 84` → `piedmont`
-- `66` → `blueRidge`
-- `67–71, 78–81` → `valleyRidge`
-- `73–76` → `gulfCoastal`
-
-**Note:** If ArcGIS endpoint is blocked, use `node scripts/generate-regions.js` (interim, uses existing inline polygons).
+| # | Title | Labels |
+|---|---|---|
+| [#18](https://github.com/loobo07/loobo07.github.io/issues/18) | OpenAPI spec for Ridge to Coast REST API v1 | `phase-3` `spec` |
+| [#19](https://github.com/loobo07/loobo07.github.io/issues/19) | `/api/v1/ecoregion` — point-in-polygon lookup endpoint | `phase-3` `api` |
+| [#20](https://github.com/loobo07/loobo07.github.io/issues/20) | `/api/v1/calendar` — planting calendar by zone and month | `phase-3` `api` |
+| [#21](https://github.com/loobo07/loobo07.github.io/issues/21) | `/api/v1/plants` — native plants by region and type | `phase-3` `api` |
+| [#22](https://github.com/loobo07/loobo07.github.io/issues/22) | Embeddable ecoregion widget (iframe snippet) | `phase-3` `enhancement` |
 
 ---
 
-## Issue 3 — Native plant expansion
+## Phase 4 — Platform
 
-**Branch:** `feat/native-plants-expansion`  
-**Label:** `enhancement`  
-**Scope:** `lib/geo-data.js` (NATIVE_PLANTS object), `tests/geo.test.js` (if count assertions exist)
-
-**What:** Each ecoregion currently has 6 native plant entries. Expand to ≥ 10.
-
-**Regions to expand:** `coastal`, `piedmont`, `ecotone`, `blueRidge`, `valleyRidge`, `gulfCoastal`
-
-**Entry schema** (must match existing):
-```javascript
-{ name: 'Common Name', latin: 'Genus species', type: 'tree|shrub|perennial|grass|fern|vine', note: '1–2 sentences.' }
-```
-
-**Acceptance criteria:**
-- Each region ≥ 10 entries (add 4+ to each)
-- No duplicate latin names within a region
-- `type` is one of: tree, shrub, perennial, grass, fern, vine
-- All 280 unit tests pass
-
-**Sources:** USDA PLANTS Database (plants.usda.gov), Lady Bird Johnson Wildflower Center (wildflower.org)
+| # | Title | Labels |
+|---|---|---|
+| [#23](https://github.com/loobo07/loobo07.github.io/issues/23) | PWA install prompt + GPS field mode | `phase-4` `pwa` |
+| [#24](https://github.com/loobo07/loobo07.github.io/issues/24) | Watershed steward education module | `phase-4` `education` |
+| [#25](https://github.com/loobo07/loobo07.github.io/issues/25) | Institutional organization accounts (custom `?layer=` GeoJSON) | `phase-4` `enhancement` |
+| [#26](https://github.com/loobo07/loobo07.github.io/issues/26) | Grant targets and funding strategy | `phase-4` `funding` |
 
 ---
 
-## Issue 4 — City marker expansion
-
-**Branch:** `feat/city-markers-expansion`  
-**Label:** `enhancement`  
-**Scope:** `lib/geo-data.js` (FALL_LINE_CITIES array)
-
-**What:** Expand from 21 to 30+ city markers.
-
-**Entry schema** (must match existing):
-```javascript
-{ name, state, lat, lon, river, region, soil, zone, note }
-// region: 'coastal' | 'piedmont' | 'blueRidge' | 'valleyRidge' | 'gulfCoastal'
-```
-
-**Candidate cities:**
-| City | State | lat | lon | region |
-|---|---|---|---|---|
-| Mobile | AL | 30.694 | -88.040 | gulfCoastal |
-| Savannah | GA | 32.080 | -81.100 | coastal |
-| Hartford | CT | 41.763 | -72.685 | piedmont |
-| Providence | RI | 41.824 | -71.413 | coastal |
-| Portland | ME | 43.661 | -70.255 | coastal |
-| Harrisburg | PA | 40.273 | -76.884 | piedmont |
-| Frederick | MD | 39.414 | -77.411 | piedmont |
-| Morgantown | WV | 39.629 | -79.956 | valleyRidge |
-| Knoxville | TN | 35.961 | -83.921 | valleyRidge |
-
-**Acceptance criteria:**
-- `FALL_LINE_CITIES.length >= 30`
-- All fields present and within BBOX (lat 24–47.5°N, lon -92 to -66.5°W)
-- All 280 unit + 85 E2E tests pass (`test_markers.py` checks count matches data)
-
----
-
-## Issue 5 — Invasive species warnings
-
-**Branch:** `feat/invasive-species`  
-**Label:** `enhancement`  
-**Scope:** `lib/geo-data.js`, `tests/geo.test.js` (new suite), `tests/e2e/test_map.py` (1 test)
-
-**What:** Add invasive species section to region popups and detail pages.
-
-**Data structure:**
-```javascript
-const INVASIVE_SPECIES = {
-  coastal:     [{ name, latin, type, threat: 'high|medium', note }],
-  piedmont:    [...],
-  blueRidge:   [...],
-  valleyRidge: [...],
-  gulfCoastal: [...],
-  ecotone:     [...],
-};
-```
-
-**Key invasives:**
-- All regions: Kudzu (*Pueraria montana*), Japanese Honeysuckle (*Lonicera japonica*)
-- Piedmont/Blue Ridge: Tree of Heaven (*Ailanthus altissima*), Chinese Wisteria
-- Coastal: Common Reed (*Phragmites australis*), Chinese Privet (*Ligustrum sinense*)
-- Gulf: Water Hyacinth (*Eichhornia crassipes*), Cogon Grass (*Imperata cylindrica*)
-- Valley & Ridge: Autumn Olive (*Elaeagnus umbellata*), Multiflora Rose (*Rosa multiflora*)
-
-**Acceptance criteria:**
-- `INVASIVE_SPECIES` with all 6 region keys, ≥ 3 entries each
-- `makeInvasivesSection(region)` returns HTML string
-- Section appears in `makeRegionDetailHTML()` and `makeRegionPopup()` output
-- New unit test suite; 1 new E2E test
-
----
-
-## Issue 6 — Seasonal planting calendar
-
-**Branch:** `feat/planting-calendar`  
-**Label:** `enhancement`  
-**Scope:** `lib/geo-data.js`, `style.css`, `tests/geo.test.js`, `tests/e2e/test_map.py`
-
-**What:** Static per-zone monthly planting calendar shown on zone detail pages.
-
-**Data structure:**
-```javascript
-const PLANTING_CALENDAR = {
-  '6b': {
-    jan: { startIndoors: ['Onions', 'Leeks'], directSow: [], transplant: [] },
-    feb: { startIndoors: ['Peppers', 'Eggplant', 'Tomatoes'], directSow: ['Spinach'], transplant: [] },
-    // ... all 12 months
-  },
-  // zones 5a–10a
-};
-```
-
-**Acceptance criteria:**
-- All zones in `data/hardiness.geojson` covered (zones 3b–10a)
-- Each zone has all 12 months with ≥ 1 activity per month
-- `makeZoneDetailHTML(zone)` includes calendar section
-- New unit test suite; 1–2 new E2E tests
-
-**Sources:** Old Farmer's Almanac (by zone), USDA PHZM zone definitions
-
----
-
-## Architecture notes for future agents
+## Architecture reference
 
 ```
-lib/geo-data.js       — all data constants + HTML builder functions (no Leaflet/DOM)
-map.js                — Leaflet init + layer logic; fetches data/regions.geojson and
-                        data/hardiness.geojson async
-data/regions.geojson  — 7-feature FeatureCollection (region polygons); load via:
-                        node scripts/generate-regions.js  (interim, from inline polygons)
-                        node scripts/extract-regions.js /path/us_eco_l3.geojson  (EPA)
-scripts/process-hardiness.js   — clips ophz GeoJSON to corridor BBOX
-scripts/extract-coastline.js   — extracts Atlantic coast from Natural Earth 50m
-scripts/extract-regions.js     — EPA Level III → data/regions.geojson
-scripts/generate-regions.js    — inline polygons → data/regions.geojson (interim)
+lib/geo-data.js          all data constants + HTML builders (no Leaflet/DOM)
+map.js                   Leaflet init; fetches data/regions.geojson + data/hardiness.geojson
+data/regions.geojson     7-feature FeatureCollection (async-loaded region polygons)
+data/hardiness.geojson   22-state hardiness zones
 
 Test commands:
-  node --test tests/geo.test.js                                  # 280 unit tests
+  node --test tests/geo.test.js
   python3 -m http.server 8765 &
-  python3 -m pytest tests/e2e/ --base-url http://localhost:8765  # 85 E2E tests
+  python3 -m pytest tests/e2e/ --base-url http://localhost:8765
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,67 +1,52 @@
 # Ridge to Coast — Roadmap
 
 ## Phase 1 — Complete ✅
-
-All merged to `master`. 280 unit tests · 85 E2E tests.
-
-- 6 region polygons: Coastal Plain, Piedmont, Blue Ridge, Valley & Ridge, NE Upland, NE Coastal, Gulf Coastal Plain
-- 21+ city markers · native plants + soil + invasive species per region · planting calendar per zone
-- Rivers interactive layer · hardiness zones 22 states · hash routing detail pages
-- `data/regions.geojson` async fetch architecture (EPA-ready)
+> 6 regions · 21+ cities · 22 states · 280 unit tests · 85 E2E tests
 
 ---
 
 ## Phase 2 — Living Data
+*Free public APIs and OpenStreetMap. No backend required.*
 
-Free public APIs + OpenStreetMap. No backend required.
-
-| # | Title | Labels |
-|---|---|---|
-| [#11](https://github.com/loobo07/loobo07.github.io/issues/11) | NWS frost advisory — "Plant now?" in zone detail pages | `phase-2` `api-integration` |
-| [#12](https://github.com/loobo07/loobo07.github.io/issues/12) | Location report page (`#detail/location/lat/lon`) | `phase-2` |
-| [#13](https://github.com/loobo07/loobo07.github.io/issues/13) | USGS streamflow status on river detail pages | `phase-2` `api-integration` |
-| [#14](https://github.com/loobo07/loobo07.github.io/issues/14) | Community gardens + native plant nurseries layer (OpenStreetMap) | `phase-2` `data` |
-| [#15](https://github.com/loobo07/loobo07.github.io/issues/15) | iNaturalist recent observations badge per region | `phase-2` `api-integration` |
-| [#16](https://github.com/loobo07/loobo07.github.io/issues/16) | Watershed delineation — click map to see contributing watershed | `phase-2` `api-integration` |
-| [#17](https://github.com/loobo07/loobo07.github.io/issues/17) | PWA service worker — offline map access | `phase-2` `pwa` |
+| Issue | Feature |
+|---|---|
+| [#11](../../issues/11) | "Plant now?" frost advisory via NWS API |
+| [#12](../../issues/12) | Location report page (`#detail/location/lat/lon`) |
+| [#13](../../issues/13) | USGS streamflow on river detail pages |
+| [#14](../../issues/14) | Community gardens layer (OpenStreetMap) |
+| [#15](../../issues/15) | iNaturalist observation badge per region |
+| [#16](../../issues/16) | Watershed delineation on map click |
+| [#17](../../issues/17) | PWA service worker (offline access) |
 
 ---
 
 ## Phase 3 — REST API
+*Cloudflare Workers. Start with the spec (#18) before any endpoint work.*
 
-Serverless (Cloudflare Workers). Spec-first: write #18 before implementing #19–#22.
-
-| # | Title | Labels |
-|---|---|---|
-| [#18](https://github.com/loobo07/loobo07.github.io/issues/18) | OpenAPI spec for Ridge to Coast REST API v1 | `phase-3` `spec` |
-| [#19](https://github.com/loobo07/loobo07.github.io/issues/19) | `/api/v1/ecoregion` — point-in-polygon lookup endpoint | `phase-3` `api` |
-| [#20](https://github.com/loobo07/loobo07.github.io/issues/20) | `/api/v1/calendar` — planting calendar by zone and month | `phase-3` `api` |
-| [#21](https://github.com/loobo07/loobo07.github.io/issues/21) | `/api/v1/plants` — native plants by region and type | `phase-3` `api` |
-| [#22](https://github.com/loobo07/loobo07.github.io/issues/22) | Embeddable ecoregion widget (iframe snippet) | `phase-3` `enhancement` |
+| Issue | Feature |
+|---|---|
+| [#18](../../issues/18) | OpenAPI spec (`api/openapi.yaml`) |
+| [#19](../../issues/19) | `GET /api/v1/ecoregion?lat=&lon=` |
+| [#20](../../issues/20) | `GET /api/v1/calendar?zone=&month=` |
+| [#21](../../issues/21) | `GET /api/v1/plants?region=&type=` |
+| [#22](../../issues/22) | Embeddable region widget (`widget.html`) |
 
 ---
 
 ## Phase 4 — Platform
 
-| # | Title | Labels |
-|---|---|---|
-| [#23](https://github.com/loobo07/loobo07.github.io/issues/23) | PWA install prompt + GPS field mode | `phase-4` `pwa` |
-| [#24](https://github.com/loobo07/loobo07.github.io/issues/24) | Watershed steward education module | `phase-4` `education` |
-| [#25](https://github.com/loobo07/loobo07.github.io/issues/25) | Institutional organization accounts (custom `?layer=` GeoJSON) | `phase-4` `enhancement` |
-| [#26](https://github.com/loobo07/loobo07.github.io/issues/26) | Grant targets and funding strategy | `phase-4` `funding` |
+| Issue | Feature |
+|---|---|
+| [#23](../../issues/23) | PWA install + GPS field mode |
+| [#24](../../issues/24) | Watershed steward education module |
+| [#25](../../issues/25) | Custom org layer (`?layer=` GeoJSON param) |
+| [#26](../../issues/26) | Grant targets (USDA · EPA · NSF) |
 
 ---
 
-## Architecture reference
-
-```
-lib/geo-data.js          all data constants + HTML builders (no Leaflet/DOM)
-map.js                   Leaflet init; fetches data/regions.geojson + data/hardiness.geojson
-data/regions.geojson     7-feature FeatureCollection (async-loaded region polygons)
-data/hardiness.geojson   22-state hardiness zones
-
-Test commands:
-  node --test tests/geo.test.js
-  python3 -m http.server 8765 &
-  python3 -m pytest tests/e2e/ --base-url http://localhost:8765
+## Dev reference
+```bash
+node --test tests/geo.test.js
+python3 -m http.server 8765 &
+python3 -m pytest tests/e2e/ --base-url http://localhost:8765
 ```


### PR DESCRIPTION
Closing — superseded by #31 (merged). The ROADMAP in #31 is the same clean format plus EPA pipeline docs, correct source URLs, and updated stats (9 regions, 51 cities, 308 tests). Nothing to resolve here.