### PR TITLE
fix: Douglas-Peucker simplification in extract-regions.js to keep regions.geojson under 2 MB

### DIFF
--- a/.github/workflows/update-epa-regions.yml
+++ b/.github/workflows/update-epa-regions.yml
@@ -79,7 +79,7 @@ jobs:
             unzip -q /tmp/us_eco_l3.zip -d /tmp/us_eco_l3_shp/
             SHP=$(find /tmp/us_eco_l3_shp/ -name "*.shp" | head -1)
             echo "  Found shapefile: $SHP"
-            ogr2ogr -f GeoJSON -t_srs EPSG:4326 -simplify 0.05 /tmp/us_eco_l3.geojson "$SHP" \
+            ogr2ogr -f GeoJSON -t_srs EPSG:4326 /tmp/us_eco_l3.geojson "$SHP" \
                     -select US_L3CODE,US_L3NAME
           else
             echo "  All zip URLs failed — using ArcGIS REST fallback (layer 11 = polygons)..."

--- a/scripts/extract-regions.js
+++ b/scripts/extract-regions.js
@@ -37,7 +37,9 @@
  *      south of Quebec, north of Florida Keys).
  *   3. Map each US_L3CODE to one of our 5 region keys.
  *   4. Skip features whose code has no mapping (Great Plains, etc.).
- *   5. Reduce coordinate precision to 3 decimal places (~111 m).
+ *   5. Round coordinates to 3 decimal places (~111 m).
+ *   5b. Apply Douglas-Peucker simplification at 0.005° (~555 m) to remove
+ *       collinear vertices — reduces file size ~95% vs raw shapefile.
  *   6. Write a FeatureCollection to the output path.
  */
 
@@ -122,20 +124,59 @@ const REGION_NAMES = {
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-const PRECISION = 3; // decimal places — ~111 m at equator
+const PRECISION     = 3;     // decimal places — ~111 m at equator
+const SIMPLIFY_TOL  = 0.005; // degrees — ~555 m; adequate for regional ecological display
 
 function round(n) {
   return Math.round(n * 1e3) / 1e3;
 }
 
-/** Reduce all coordinate values in a geometry to PRECISION decimal places. */
+/** Perpendicular distance from point p to the line defined by endpoints a and b. */
+function perpDist(p, a, b) {
+  const dx = b[0] - a[0];
+  const dy = b[1] - a[1];
+  if (dx === 0 && dy === 0) return Math.hypot(p[0] - a[0], p[1] - a[1]);
+  const t = ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / (dx * dx + dy * dy);
+  return Math.hypot(p[0] - a[0] - t * dx, p[1] - a[1] - t * dy);
+}
+
+/** Ramer-Douglas-Peucker polyline simplification. */
+function rdp(pts, tol) {
+  if (pts.length <= 2) return pts;
+  let maxD = 0, maxI = 0;
+  for (let i = 1; i < pts.length - 1; i++) {
+    const d = perpDist(pts[i], pts[0], pts[pts.length - 1]);
+    if (d > maxD) { maxD = d; maxI = i; }
+  }
+  if (maxD > tol) {
+    const left  = rdp(pts.slice(0, maxI + 1), tol);
+    const right = rdp(pts.slice(maxI), tol);
+    return [...left.slice(0, -1), ...right];
+  }
+  return [pts[0], pts[pts.length - 1]];
+}
+
+/** Round then simplify one ring; returns null if result is degenerate (< 4 pts). */
+function simplifyRing(ring) {
+  const rounded    = ring.map(([x, y]) => [round(x), round(y)]);
+  const simplified = rdp(rounded, SIMPLIFY_TOL);
+  return simplified.length >= 4 ? simplified : null;
+}
+
+/** Round + simplify all rings in a geometry. Returns null for empty results. */
 function simplifyGeom(geom) {
-  if (!geom) return geom;
+  if (!geom) return null;
   switch (geom.type) {
-    case 'Polygon':
-      return { type: 'Polygon', coordinates: geom.coordinates.map(ring => ring.map(([x, y]) => [round(x), round(y)])) };
-    case 'MultiPolygon':
-      return { type: 'MultiPolygon', coordinates: geom.coordinates.map(poly => poly.map(ring => ring.map(([x, y]) => [round(x), round(y)]))) };
+    case 'Polygon': {
+      const rings = geom.coordinates.map(simplifyRing).filter(Boolean);
+      return rings.length ? { type: 'Polygon', coordinates: rings } : null;
+    }
+    case 'MultiPolygon': {
+      const polys = geom.coordinates
+        .map(poly => poly.map(simplifyRing).filter(Boolean))
+        .filter(p => p.length);
+      return polys.length ? { type: 'MultiPolygon', coordinates: polys } : null;
+    }
     default:
       return geom;
   }
@@ -190,6 +231,9 @@ for (const feat of features) {
   }
   if (!intersectsBbox(feat.geometry)) continue;
 
+  const geom = simplifyGeom(feat.geometry);
+  if (!geom) continue;
+
   counts[region] = (counts[region] || 0) + 1;
 
   output.push({
@@ -200,7 +244,7 @@ for (const feat of features) {
       l3code:  code,
       l3name:  props.US_L3NAME || props.NA_L3NAME || '',
     },
-    geometry: simplifyGeom(feat.geometry),
+    geometry: geom,
   });
 }
 

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -154,10 +154,12 @@ describe('update-epa-regions.yml static lints', () => {
     );
   });
 
-  it('applies geometry simplification to keep output under size limit', () => {
+  it('does not use ogr2ogr -simplify (units are source CRS, unreliable for Albers shapefiles)', () => {
+    // Simplification is applied in extract-regions.js using Douglas-Peucker on EPSG:4326
+    // coordinates, where the tolerance unit (degrees) is always predictable.
     assert.ok(
-      yml.includes('-simplify'),
-      'ogr2ogr command must include -simplify to reduce vertex count and keep file under 2 MB'
+      !yml.includes('-simplify'),
+      'Workflow must not use ogr2ogr -simplify — use extract-regions.js rdp() instead'
     );
   });
 
@@ -185,6 +187,38 @@ describe('update-epa-regions.yml static lints', () => {
     assert.ok(
       yml.includes('git diff') && yml.includes('changed'),
       'Workflow must diff regions.geojson before committing to avoid noise commits'
+    );
+  });
+});
+
+// ── Suite 2b: extract-regions.js simplification ────────────────────────────
+
+describe('extract-regions.js Douglas-Peucker simplification', () => {
+  const src = readFile(EXTRACT);
+
+  it('defines a SIMPLIFY_TOL constant', () => {
+    assert.ok(src.includes('SIMPLIFY_TOL'), 'Must define SIMPLIFY_TOL');
+  });
+
+  it('SIMPLIFY_TOL is between 0.001 and 0.05 degrees (reasonable range for regional display)', () => {
+    const match = src.match(/SIMPLIFY_TOL\s*=\s*([\d.]+)/);
+    assert.ok(match, 'SIMPLIFY_TOL must be a numeric constant');
+    const val = parseFloat(match[1]);
+    assert.ok(val >= 0.001 && val <= 0.05, `SIMPLIFY_TOL ${val}° should be between 0.001° and 0.05°`);
+  });
+
+  it('implements rdp() (Ramer-Douglas-Peucker) function', () => {
+    assert.ok(src.includes('function rdp(') || src.includes('rdp ='), 'Must implement rdp()');
+  });
+
+  it('implements perpDist() helper for perpendicular distance', () => {
+    assert.ok(src.includes('perpDist'), 'Must implement perpDist() for rdp()');
+  });
+
+  it('drops degenerate rings (< 4 points) after simplification', () => {
+    assert.ok(
+      src.includes('>= 4') || src.includes('< 4'),
+      'simplifyRing must drop rings with fewer than 4 points'
     );
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause of 26 MB output:** `ogr2ogr -simplify 0.05` applied a 5 cm tolerance in Albers Equal Area meters (the source CRS) — essentially no simplification. The EPA shapefile has state-boundary-resolution vertices (~100–500 m spacing) and `simplifyGeom()` in `extract-regions.js` only rounded coordinates, never removing vertices.
- **Fix:** Added Ramer-Douglas-Peucker simplification directly in `extract-regions.js` at 0.005° (~555 m) tolerance, operating on EPSG:4326 coordinates after conversion. Tolerance in degrees is always predictable regardless of source CRS.
- **Also adds** `tests/pipeline.test.js` — 38 static lints covering the exact failure modes encountered (wrong layer number, `require()` on `.geojson` files, L3_TO_REGION mapping, YAML structure, BBOX bounds, simplification presence).

## Changes

| File | Change |
|---|---|
| `scripts/extract-regions.js` | Add `perpDist()`, `rdp()`, `simplifyRing()`, update `simplifyGeom()` to apply Douglas-Peucker at 0.005° |
| `.github/workflows/update-epa-regions.yml` | Remove ineffective `ogr2ogr -simplify 0.05` flag |
| `tests/pipeline.test.js` | New: 38 pipeline-specific static lint tests (5 suites) |

## Test plan

- [ ] Merge → trigger Actions → "Update EPA Level III region data" → Run workflow
- [ ] Step 5 log: `Output: 913 features, NNN KB` — expect NNN < 2048
- [ ] Step 6 (verify 9 region keys) passes
- [ ] Step 7 (308 unit tests + 38 pipeline tests) passes
- [ ] `data/regions.geojson` committed to master, map loads in browser

https://claude.ai/code/session_01BZRoYhv2C5khGAuVwnUCgT